### PR TITLE
MNT: Fix version metadata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
 {% set name = "sherpa" %}
-{% set version = "v2.2.16" %}
+{% set version = "2.2.16" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://gitlab.com/sherpa-team/sherpa/-/archive/{{ version }}/sherpa-{{ version }}.tar.gz
+  url: https://gitlab.com/sherpa-team/sherpa/-/archive/v{{ version }}/sherpa-v{{ version }}.tar.gz
   sha256: b2680da5682c78623635ae88a5ff5af346cf74c1be95ee9177e8f9080d418e76
   patches:
     # Avoid issue with compiling .pyc files during packaging step post build
@@ -17,7 +17,7 @@ source:
 build:
   # FIXME: Get macOS builds working
   skip: true  # [not linux]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
* Avoid having the 'v' appear multiple times in rendered metadata.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
