### PR TITLE
FIX: Keep all shared libraries in DT_NEEDED

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,14 +37,20 @@ export CFLAGS="${CFLAGS//${search}/${replace}}"
 export CXXFLAGS="${CXXFLAGS//${search}/${replace}}"
 export FFLAGS="${FFLAGS//${search}/${replace}}"
 
-# On macOS, Sherpa links every shared library with "-undefined dynamic_lookup"
-# (CMakeLists.txt), so cross-library references such as MODEL::as are emitted as
-# flat-namespace undefined symbols rather than recorded two-level dependencies.
-# conda's default "-Wl,-dead_strip_dylibs" then strips the load command for the
-# dylib that actually provides such a symbol (e.g. libModelMain, which defines
-# MODEL::as) because it sees no two-level use of it -- so at runtime dyld aborts
-# with "symbol not found in flat namespace '__ZN5MODEL2asE'". Drop the flag so
-# the linked dylibs stay loaded. No-op on Linux (its LDFLAGS lack the flag).
+# Sherpa's shared libraries have incomplete inter-library link dependencies and
+# rely on the executable loading every library into one global symbol scope (its
+# libs are built with undefined symbols left to resolve at runtime). conda's
+# default link-time GC flags prune libraries whose symbols a given object does
+# not *directly* reference, which breaks any isolated consumer that must resolve
+# those cross-library symbols on its own:
+#   * Linux "-Wl,--as-needed" drops e.g. libYFSCEEX from _Sherpa.so's DT_NEEDED,
+#     so "import Sherpa" fails with
+#     "libYFSMain.so: undefined symbol: YFS::Ceex_Base::Ceex_Base(...)".
+#   * macOS "-Wl,-dead_strip_dylibs" drops e.g. libModelMain, so Sherpa aborts
+#     with "symbol not found in flat namespace '__ZN5MODEL2asE'" (MODEL::as).
+# Drop both so the linked libraries stay in DT_NEEDED / load commands. Each
+# substitution is a no-op on the platform whose LDFLAGS lack that flag.
+export LDFLAGS="${LDFLAGS//-Wl,--as-needed/}"
 export LDFLAGS="${LDFLAGS//-Wl,-dead_strip_dylibs/}"
 
 cmake ${CMAKE_ARGS} \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -26,7 +26,7 @@ source:
     - strip-null-bytes-in-Library_Loader.patch
 
 build:
-  number: 0
+  number: 1
   skip: win
 
 requirements:
@@ -105,11 +105,15 @@ tests:
         - SHERPA-MC/YFS/*
       files:
         - share/SHERPA-MC/*
-        - etc/conda/test-files/sherpa/0/*
-        # Python bindings (one build per python version; path is version-specific)
+        - etc/conda/test-files/sherpa/1/*
+        # Python bindings (path is Python version specific)
         - lib/python*/site-packages/Sherpa.py
         - lib/python*/site-packages/_Sherpa.so
         - lib/python*/site-packages/__pycache__/Sherpa.cpython-*.pyc
+
+  - python:
+      imports:
+        - Sherpa
 
   - files:
       source:


### PR DESCRIPTION
* Remove `-Wl,--as-needed` from `LDFLAGS` as Sherpa's shared libraries have incomplete inter-library link dependencies and rely on the executable loading every library into one global symbol scope (its libs are built with undefined symbols left to resolve at runtime). conda-forge's default link-time GC flags prune libraries whose symbols a given object does not directly reference, which breaks any isolated consumer that must resolve those cross-library symbols on its own.
* Add Python library import test.
* Bump build number.
* Amends PR https://github.com/conda-forge/sherpa-feedstock/pull/15

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
